### PR TITLE
Interrupt include not necessary on Pure Hw CTC Mode

### DIFF
--- a/Timers/Timers.tex
+++ b/Timers/Timers.tex
@@ -880,7 +880,6 @@ Amazing how simple it is, isn't it! Well, we can already fill in almost all of t
 \begin{center}
 \begin{lstlisting}
 #include <avr/io.h>
-#include <avr/interrupt.h>
 
 int main (void)
 {
@@ -911,7 +910,6 @@ To make the channel A Compare Output pin toggle on each compare, the datasheet s
 \begin{center}
 \begin{lstlisting}
 #include <avr/io.h>
-#include <avr/interrupt.h>
 
 int main (void)
 {


### PR DESCRIPTION
Hi Dean,
I'm Testato, i follow you on AvrFreaks forum :-)

Your tutorial is always very good, i made 3 patch on Timer document, this is the first
- Interrupt include not necessary on Pure Hw CTC Mode
