### PR TITLE
Some fixes

### DIFF
--- a/ManagingLargeProjects/ManagingLargeProjects.tex
+++ b/ManagingLargeProjects/ManagingLargeProjects.tex
@@ -51,7 +51,6 @@ ProcessByte()
 Speaker.c
 \begin{center}
 \begin{lstlisting}
-Code:
 SetupSpeaker()
 Beep()
 \end{lstlisting}

--- a/USART/USART.tex
+++ b/USART/USART.tex
@@ -102,7 +102,7 @@ Given my example project using a system clock of 7372800Hz and a baud rate of 96
 \begin{displaymath}
 \begin{array}{rcl}
     \text{Baud Value} & = & \frac{ \text{F\subscript{cpu}} }{ 16 \times \text{BAUD} } \\
-    \text{Baud Value} & = & \frac{ 7372800 } { 9600 \times 16 } - 1) \\
+    \text{Baud Value} & = & \frac{ 7372800 } { 9600 \times 16 } - 1 \\
     \text{Baud Value} & = & \frac{ 7372800 } { 153600 } - 1 \\
     \text{Baud Value} & = & 48 - 1 \\
     \text{Baud Value} & = & 47 \\
@@ -117,7 +117,7 @@ To make our life easier, we can turn this formula into a set of handy macros. Th
 \begin{lstlisting}
 #define USART_BAUDRATE 9600
 
-// Naiive Version - has rounding bugs!
+// Naive Version - has rounding bugs!
 //#define BAUD_PRESCALE (((F_CPU / (USART_BAUDRATE * 16UL))) - 1)
 
 // Better Version - see text below


### PR DESCRIPTION
While reading through the tutorials I found some bugs.
I have not regenerated the PDF files.

About the USART calculation it was not clear to me why you need to add the -1. However I've used this before and I know its about rounding etc. I know that its correct etc, but for a new user this might be confusing that a -1 pops up. Or maybe I have not read carefully enough?

Great tutorials anyways. It would be nice if you could also add a tutorial about USART Interrupt sending, not only receiving. I found that one a bit more tricky.
